### PR TITLE
Include missing package in setup.py file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--i https://pypi.org/simple
 appdirs==1.4.3
 atomicwrites==1.3.0
 attrs==19.3.0
@@ -21,6 +20,7 @@ mccabe==0.6.1
 more-itertools==8.1.0
 mypy-extensions==0.4.3
 mypy==0.740
+nose==1.3.7
 packaging==20.1
 pathspec==0.7.0
 pluggy==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'prometheus-client>=0.6.0',
+        'APScheduler>=3.6.3',
+        'flask>=1.0.0',
+        'requests',
     ],
     extras_require={
         'flask': ['Flask>=1.0.0'],


### PR DESCRIPTION
`setup.py` file was missing some core dependencies. The `nose` was included in the `requirements.txt` file as a basic package for tests.